### PR TITLE
Fix when the device is landscape the windows size is not correct

### DIFF
--- a/FVCustomAlertView/FVCustomAlertView/FVCustomAlertView.m
+++ b/FVCustomAlertView/FVCustomAlertView/FVCustomAlertView.m
@@ -47,6 +47,11 @@ static const CGFloat kOtherIconsSize = 30;
 
     //get window size and position
     CGRect windowRect = [[UIScreen mainScreen] bounds];
+    
+    // Fix bug, when the device is landscape the windows size is not correct
+    if (UIInterfaceOrientationIsLandscape([[UIApplication sharedApplication] statusBarOrientation])) {
+        windowRect.size = CGSizeMake(windowRect.size.height, windowRect.size.width);
+    }
 
     //create the final view with a special tag
     UIView *resultView = [[UIView alloc] initWithFrame:windowRect];


### PR DESCRIPTION
When my using  FVCustomAlertView in my ipad is landscape, the position of view is not corrent.
