### PR TITLE
Correct the spelling of Xcode in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ it, simply add the following line to your Podfile:
     pod "FVCustomAlertView"
 
 ### Use FVCustomAlertView as a static library
-Drag the .xcodeproj file into your XCode project and add it as a Target in your Build Phases. Don't forget to add libFVCustomAlertView.a in Link Binary With Library and set the -ObjC flag in Other Linker Flags.
+Drag the .xcodeproj file into your Xcode project and add it as a Target in your Build Phases. Don't forget to add libFVCustomAlertView.a in Link Binary With Library and set the -ObjC flag in Other Linker Flags.
 
 ### Manually add the files to your project
 


### PR DESCRIPTION

This pull request corrects the spelling of **Xcode** :sweat_smile:
https://developer.apple.com/xcode/

Created with [`xcode-readme`](https://github.com/dkhamsing/xcode-readme).
